### PR TITLE
Add comprehensive .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.so
+*.egg
+*.egg-info/
+dist/
+build/
+.eggs/
+pip-wheel-metadata/
+venv/
+ENV/
+env/
+.venv/
+.ipynb_checkpoints/
+
+# Node artifacts
+node_modules/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor artifacts
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*~


### PR DESCRIPTION
## Summary
- prevent common Python, Node, and editor build artifacts from being committed by adding a repo-wide `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684503f7ca008331b9116b3fa2d8b3f1